### PR TITLE
fix: support .tsx source files

### DIFF
--- a/src/services/resourceMatcher.ts
+++ b/src/services/resourceMatcher.ts
@@ -10,7 +10,7 @@ const SOURCE_IGNORE_PATTERNS = [
   '**/*.d.ts',
   '**/test/**',
   '**/e2e/**',
-  '**/*.test.{js,ts}',
+  '**/*.test.{js,ts,tsx}',
   '**/__mocks__/**',
   '**/__tests__/**'
 ]
@@ -36,7 +36,8 @@ class ResourceMatcher implements IResourceMatcher {
   public async getSourceFiles(): Promise<string[]> {
     const rawFiles = await Promise.all([
       this.getFiles('src/**/*.js', SOURCE_IGNORE_PATTERNS),
-      this.getFiles('src/**/*.ts', SOURCE_IGNORE_PATTERNS)
+      this.getFiles('src/**/*.ts', SOURCE_IGNORE_PATTERNS),
+      this.getFiles('src/**/*.tsx', SOURCE_IGNORE_PATTERNS)
     ])
 
     return flatten<string>(rawFiles)


### PR DESCRIPTION
TypeScript React-files have the `.tsx` extension.
Previously, only `.js` and `.ts` source-files were crawled.
Meaning that this plugin didn't check for keys inside `.tsx` files, only in `.js` and `.ts` files.

this commit adds support for `.tsx` source files.